### PR TITLE
Add State_index to traceinspector output and sort output by index

### DIFF
--- a/traceinspector/output.go
+++ b/traceinspector/output.go
@@ -3,6 +3,7 @@ package traceinspector
 import (
 	"encoding/json"
 	"os"
+	"sort"
 	"traceinspector/imp"
 )
 
@@ -16,11 +17,13 @@ const (
 )
 
 type AnalyzerOutputHandler struct {
-	Debugs []AnalyzerOutput
+	state_index int `json:"-"`
+	Debugs      []AnalyzerOutput
 }
 
 type AnalyzerOutput struct {
 	Type          AnalyzerOutputType
+	State_index   int
 	Function_name imp.ImpFunctionName
 	Line_number   int
 	Node_id       NodeID
@@ -33,6 +36,7 @@ func (ao *AnalyzerOutputHandler) Print() {
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetEscapeHTML(false)
 	enc.SetIndent("", "    ")
+	sort.Slice(ao.Debugs, func(i, j int) bool { return ao.Debugs[i].State_index < ao.Debugs[j].State_index })
 	enc.Encode(ao)
 	// out := &bytes.Buffer{}
 	// json.Compact(out, buf.Bytes())
@@ -40,19 +44,24 @@ func (ao *AnalyzerOutputHandler) Print() {
 }
 
 func (ao *AnalyzerOutputHandler) write_info(node_location CFGNodeLocation, msg string) {
-	ao.Debugs = append(ao.Debugs, AnalyzerOutput{Type: AnalyzerOutput_info, Function_name: node_location.Function_name, Line_number: node_location.Line_num, Node_id: node_location.Id, Msg: msg})
+	ao.Debugs = append(ao.Debugs, AnalyzerOutput{Type: AnalyzerOutput_info, State_index: ao.state_index,
+		Function_name: node_location.Function_name, Line_number: node_location.Line_num, Node_id: node_location.Id, Msg: msg})
 }
 
 func (ao *AnalyzerOutputHandler) write_warning(node_location CFGNodeLocation, msg string) {
-	ao.Debugs = append(ao.Debugs, AnalyzerOutput{Type: AnalyzerOutput_warning, Function_name: node_location.Function_name, Line_number: node_location.Line_num, Node_id: node_location.Id, Msg: msg})
+	ao.Debugs = append(ao.Debugs, AnalyzerOutput{Type: AnalyzerOutput_warning, State_index: ao.state_index,
+		Function_name: node_location.Function_name, Line_number: node_location.Line_num, Node_id: node_location.Id, Msg: msg})
 }
 
 func (ao *AnalyzerOutputHandler) write_error(node_location CFGNodeLocation, msg string) {
-	ao.Debugs = append(ao.Debugs, AnalyzerOutput{Type: AnalyzerOutput_error, Function_name: node_location.Function_name, Line_number: node_location.Line_num, Node_id: node_location.Id, Msg: msg})
+	ao.Debugs = append(ao.Debugs, AnalyzerOutput{Type: AnalyzerOutput_error, State_index: ao.state_index,
+		Function_name: node_location.Function_name, Line_number: node_location.Line_num, Node_id: node_location.Id, Msg: msg})
 	ao.Print()
 	os.Exit(0)
 }
 
 func (ao *AnalyzerOutputHandler) write_update_node_state(node_location CFGNodeLocation, state_str string, msg string) {
-	ao.Debugs = append(ao.Debugs, AnalyzerOutput{Type: AnalyzerOutput_update_node, Function_name: node_location.Function_name, Line_number: node_location.Line_num, Node_id: node_location.Id, Node_state: state_str, Msg: msg})
+	ao.Debugs = append(ao.Debugs, AnalyzerOutput{Type: AnalyzerOutput_update_node, State_index: ao.state_index,
+		Function_name: node_location.Function_name, Line_number: node_location.Line_num, Node_id: node_location.Id, Node_state: state_str, Msg: msg})
+	ao.state_index++
 }


### PR DESCRIPTION
Example output:
```
{
    "Debugs": [
        {
            "Type": "update_node",
            "State_index": 0,
            "Function_name": "main",
            "Line_number": 6,
            "Node_id": 16,
            "Node_state": "{}",
            "Msg": "Join global memory state"
        },
        {
            "Type": "update_node",
            "State_index": 1,
            "Function_name": "main",
            "Line_number": 7,
            "Node_id": 13,
            "Node_state": "{a : [1, 1]}",
            "Msg": "Join global memory state"
        },
        ...
```
